### PR TITLE
Generate random namespace id

### DIFF
--- a/mimirtool/common.go
+++ b/mimirtool/common.go
@@ -1,13 +1,17 @@
 package mimirtool
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
+	"math/rand"
 )
 
-func hash(s string) string {
-	sha := sha256.Sum256([]byte(s))
-	return hex.EncodeToString(sha[:])
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func randStringBytes(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
 }
 
 func stringValueMap(src map[string]interface{}) map[string]string {

--- a/mimirtool/resource_ruler_namespace.go
+++ b/mimirtool/resource_ruler_namespace.go
@@ -114,7 +114,7 @@ func rulerNamespaceCreate(ctx context.Context, d *schema.ResourceData, meta any)
 		}
 	}
 
-	d.SetId(hash(namespace))
+	d.SetId(randStringBytes(64))
 	return rulerNamespaceRead(ctx, d, meta)
 }
 


### PR DESCRIPTION
When rules namespace resources are created they get assigned an hash of the namespace attribute as internal ID.
This leads to clashes when provisioning multiple rule groups within the same namespace.

- internally, this ID is not managed to fetch or delete the resource (the namespace attribute is used instead)
- the generated random ID strings are 64 bytes long to keep the same length, just in case

Pending PR against upstream project: https://github.com/ovh/terraform-provider-mimirtool/pull/25